### PR TITLE
fix: multiple interface implementation providers are invalid

### DIFF
--- a/app/src/main/java/cn/jailedbird/arouter/ksp/MainActivity.kt
+++ b/app/src/main/java/cn/jailedbird/arouter/ksp/MainActivity.kt
@@ -2,7 +2,10 @@ package cn.jailedbird.arouter.ksp
 
 import android.os.Bundle
 import android.widget.Button
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import cn.jailedbird.arouter.ksp.service.ITestService1
+import cn.jailedbird.arouter.ksp.service.ITestService2
 import com.alibaba.android.arouter.facade.annotation.Autowired
 import com.alibaba.android.arouter.launcher.ARouter
 
@@ -29,6 +32,14 @@ class MainActivity : AppCompatActivity() {
                 .withObject("arrayList", arrayListOf("1", "2", "3"))
                 .withObject("list", mutableListOf("1", "2", "3", "4"))
                 .navigation(this)
+        }
+        
+        val testService1 = ARouter.getInstance()
+            .navigation(ITestService1::class.java)
+        val testService2 = ARouter.getInstance()
+            .navigation(ITestService2::class.java)
+        if (testService1 != null && testService2 != null && testService1 === testService2) {
+            Toast.makeText(this, "success", Toast.LENGTH_SHORT).show()
         }
     }
 }

--- a/app/src/main/java/cn/jailedbird/arouter/ksp/service/ITestService1.kt
+++ b/app/src/main/java/cn/jailedbird/arouter/ksp/service/ITestService1.kt
@@ -1,0 +1,12 @@
+package cn.jailedbird.arouter.ksp.service
+
+import com.alibaba.android.arouter.facade.template.IProvider
+
+/**
+ * .
+ *
+ * @author 985892345
+ * 2023/5/28 16:58
+ */
+interface ITestService1 : IProvider {
+}

--- a/app/src/main/java/cn/jailedbird/arouter/ksp/service/ITestService2.kt
+++ b/app/src/main/java/cn/jailedbird/arouter/ksp/service/ITestService2.kt
@@ -1,0 +1,12 @@
+package cn.jailedbird.arouter.ksp.service
+
+import com.alibaba.android.arouter.facade.template.IProvider
+
+/**
+ * .
+ *
+ * @author 985892345
+ * 2023/5/28 16:59
+ */
+interface ITestService2 : IProvider {
+}

--- a/app/src/main/java/cn/jailedbird/arouter/ksp/service/TestServiceImpl.kt
+++ b/app/src/main/java/cn/jailedbird/arouter/ksp/service/TestServiceImpl.kt
@@ -1,0 +1,16 @@
+package cn.jailedbird.arouter.ksp.service
+
+import android.content.Context
+import com.alibaba.android.arouter.facade.annotation.Route
+
+/**
+ * .
+ *
+ * @author 985892345
+ * 2023/5/28 16:58
+ */
+@Route(path = "/test/service")
+class TestServiceImpl : ITestService1, ITestService2 {
+  override fun init(context: Context) {
+  }
+}

--- a/compiler/src/main/java/cn/jailedbird/arouter/ksp/compiler/RouteSymbolProcessorProvider.kt
+++ b/compiler/src/main/java/cn/jailedbird/arouter/ksp/compiler/RouteSymbolProcessorProvider.kt
@@ -146,13 +146,11 @@ class RouteSymbolProcessorProvider : SymbolProcessorProvider {
                                 if (name == Consts.IPROVIDER) {
                                     providersMap[element.qualifiedName!!.asString()] = routeMeta
                                     routeDoc.addPrototype(name)
-                                    break
                                 } else if (declaration.isSubclassOf(Consts.IPROVIDER)) {
                                     // This interface extend the IProvider, so it can be used for mark provider
                                     if (!name.isNullOrEmpty()) {
                                         providersMap[name] = routeMeta
                                         routeDoc.addPrototype(name)
-                                        break
                                     }
                                 }
                             }


### PR DESCRIPTION
# 问题描述
在一个类实现了多个接口时加载会失效，与ARouter官方的行为不一致
## 代码示例
```kotlin
interface ITestService1 : IProvider

interface ITestService2 : IProvider

@Route(path = "/test/service")
class TestServiceImpl : ITestService1, ITestService2 {
  override fun init(context: Context) {
  }
}
```
ARouter官方的会生成如下代码：
![image](https://github.com/JailedBird/ArouterKspCompiler/assets/62180145/dcaf1862-5c0f-4c9b-a7d8-a3b75b9ae578)
可以发现有两个，但是目前你的ksp只生成了一个：
![image](https://github.com/JailedBird/ArouterKspCompiler/assets/62180145/8866495a-fed1-4a4b-8c56-e16821895aea)


## 解决方法
取消掉 RouteSymbolProcessorProvider 类中跳出循环的 break
![image](https://github.com/JailedBird/ArouterKspCompiler/assets/62180145/1e9a11fb-3a3e-4ba5-92cd-a3c256fd7ff1)
